### PR TITLE
Tech report showcases: Add scripts for Qwen3-series

### DIFF
--- a/best_practice/qwen3/readme.md
+++ b/best_practice/qwen3/readme.md
@@ -57,10 +57,11 @@ Experiment Setup:
 - Dispatcher: HybridEP
 - NVLink Domain Size: 72
 
-| GPU | SEQ_LEN | NNODES | Precision | TP | PP | VPP | EP | MBS | GBS | TFLOPS | Notes |
-| --- | ------- | ------ | --------- | -- | -- | --- | -- | --- | --- | ------ | ----- |
-| GB200 | 4096 | 64 | BF16   | 1 | 8 | 1 | 8  | 1 | 8192 | 750 | |
-| GB200 | 4096 | 64 | MXFP8  | 1 | 4 | 6 | 64 | 3 | 3072 | 919 | activation offloading required |
+| GPU | SEQ_LEN | NNODES | Precision | TP | PP | VPP | CP | EP | MBS | GBS | TFLOPS | Notes |
+| --- | ------- | ------ | --------- | -- | -- | --- | -- | -- | --- | --- | ------ | ----- |
+| GB200 | 4096   | 64 | BF16  | 1 | 8 | 1  | 1 | 8  | 1 | 8192 | 750  | |
+| GB200 | 4096   | 64 | MXFP8 | 1 | 4 | 6  | 1 | 64 | 3 | 3072 | 919  | activation offloading required |
+| GB200 | 131072 | 32 | MXFP8 | 4 | 4 | 12 | 4 | 32 | 1 | 1024 | 1150 | long context |
 
 Command (BF16):
 
@@ -72,6 +73,12 @@ Command (MXFP8):
 
 ```bash
 PR=mxfp8 MBS=3 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep A2A_OVERLAP=1 TP=1 PP=4 VPP=6 EP=64 SEGMENT=16 NNODES=64 GBS=3072 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess --fine-grained-activation-offloading --offload-modules expert_fc1 moe_act --delay-offload-until-cuda-graph --use-separate-send-recv-groups
+```
+
+Command (MXFP8, 128k long context):
+
+```bash
+PR=mxfp8 SEQ_LEN=131072 CP=4 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=4 PP=4 VPP=12 EP=32 NNODES=32 MBS=1 GBS=1024 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing
 ```
 
 Notes:
@@ -88,17 +95,10 @@ Experiment Setup:
 
 | GPU | SEQ_LEN | NNODES | Precision | TP | PP | VPP | CP | EP | MBS | GBS | TFLOPS | Notes |
 | --- | ------- | ------ | --------- | -- | -- | --- | -- | -- | --- | --- | ------ | ----- |
-| GB300 | 4096   | 64 | MXFP8 | 1 | 4 | 1  | 1 | 32 | 2 | 8192 | 974  | |
-| GB300 | 131072 | 32 | MXFP8 | 4 | 4 | 12 | 4 | 32 | 1 | 1024 | 1150 | long context |
+| GB300 | 4096 | 16 | MXFP8 | 1 | 1 | 1 | 1 | 64 | 1 | 8192 | 1055 | |
 
-Command (standard):
-
-```bash
-PR=mxfp8 MBS=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=1 PP=4 VPP=1 EP=32 NNODES=64 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
-```
-
-Command (long context, 128k):
+Command:
 
 ```bash
-PR=mxfp8 SEQ_LEN=131072 CP=4 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=4 PP=4 VPP=12 EP=32 NNODES=32 MBS=1 GBS=1024 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing
+PR=mxfp8 MBS=1 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=16 A2A_OVERLAP=1 TP=1 PP=1 VPP=1 EP=64 NNODES=16 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
 ```

--- a/best_practice/qwen3/readme.md
+++ b/best_practice/qwen3/readme.md
@@ -1,5 +1,7 @@
 ## Performance Results
 
+### H100
+
 Experiment Setup:
 - 256 H100 GPUS
 - NVLink 4th Generation
@@ -19,7 +21,7 @@ Experiment Setup:
 
 *Note: The performance of Qwen3-Next-80B-A3B is not well tuned. Acceleration is coming soon!*
 
-### Long Context
+#### Long Context
 
 Experiment Setup:
 - NVLink 4th Generation
@@ -45,3 +47,58 @@ Notes:
 
 * Selective recompute requires PR [!2125](https://github.com/NVIDIA/TransformerEngine/pull/2125) of TransformerEngine to fix a memory issue of sequence parallel. If you run OOM without this PR, please use `--recompute-granularity full --recompute-method uniform --recompute-num-layers 1` to enable full recompute.
 * Add `--moe-router-force-load-balancing` to test forced load balancing.
+
+---
+
+### GB200
+
+Experiment Setup:
+- Model: Qwen3-235B-A22B
+- Dispatcher: HybridEP
+- NVLink Domain Size: 72
+
+| GPU | SEQ_LEN | NNODES | Precision | TP | PP | VPP | EP | MBS | GBS | TFLOPS | Notes |
+| --- | ------- | ------ | --------- | -- | -- | --- | -- | --- | --- | ------ | ----- |
+| GB200 | 4096 | 64 | BF16   | 1 | 8 | 1 | 8  | 1 | 8192 | 750 | |
+| GB200 | 4096 | 64 | MXFP8  | 1 | 4 | 6 | 64 | 3 | 3072 | 919 | activation offloading required |
+
+Command (BF16):
+
+```bash
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=2 PR=bf16 A2A_OVERLAP=0 TP=1 PP=8 VPP=1 EP=8 NNODES=64 MBS=1 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
+```
+
+Command (MXFP8):
+
+```bash
+PR=mxfp8 MBS=3 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep A2A_OVERLAP=1 TP=1 PP=4 VPP=6 EP=64 SEGMENT=16 NNODES=64 GBS=3072 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess --fine-grained-activation-offloading --offload-modules expert_fc1 moe_act --delay-offload-until-cuda-graph --use-separate-send-recv-groups
+```
+
+Notes:
+* MXFP8 config requires the activation offloading feature. Please check the PR status before using it.
+
+---
+
+### GB300
+
+Experiment Setup:
+- Model: Qwen3-235B-A22B
+- Dispatcher: HybridEP
+- NVLink Domain Size: 72
+
+| GPU | SEQ_LEN | NNODES | Precision | TP | PP | VPP | CP | EP | MBS | GBS | TFLOPS | Notes |
+| --- | ------- | ------ | --------- | -- | -- | --- | -- | -- | --- | --- | ------ | ----- |
+| GB300 | 4096   | 64 | MXFP8 | 1 | 4 | 1  | 1 | 32 | 2 | 8192 | 974  | |
+| GB300 | 131072 | 32 | MXFP8 | 4 | 4 | 12 | 4 | 32 | 1 | 1024 | 1150 | long context |
+
+Command (standard):
+
+```bash
+PR=mxfp8 MBS=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=1 PP=4 VPP=1 EP=32 NNODES=64 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
+```
+
+Command (long context, 128k):
+
+```bash
+PR=mxfp8 SEQ_LEN=131072 CP=4 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=4 PP=4 VPP=12 EP=32 NNODES=32 MBS=1 GBS=1024 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing
+```

--- a/best_practice/qwen3/run_gb200_235b.sh
+++ b/best_practice/qwen3/run_gb200_235b.sh
@@ -1,0 +1,40 @@
+# Cluster variables
+export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
+export ACCOUNT=${ACCOUNT:-}
+export MEGATRON_PATH=${MEGATRON_PATH:-}
+export PARTITION=${PARTITION:-}
+export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
+export CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
+export CLUSTER=${CLUSTER:-}
+export BINDPCIE_PATH=${BINDPCIE_PATH:-}
+
+# GB env
+# export SEGMENT=${SEGMENT:-16} # Should be EP // 4
+export NVLINK_DOMAIN_SIZE=72
+## HybridEP settings, automatically set if using latest HybridEP
+# export USE_MNNVL=1
+# export NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=32 # should be similar as EP
+
+# Model selection parameters
+export MODEL=${MODEL:-Qwen3-235B-A22B}
+export WANDB_PROJECT=${WANDB_PROJECT:-}
+export OUTPUT_PATH=${OUTPUT_PATH:-}
+
+# # Training parameters
+export PROFILE=0 # whether to profile the model with nsys profile
+export PRETRAIN=0 # whether train the model from scratch
+export MBS=${MBS:-1}
+export SEQ_LEN=${SEQ_LEN:-4096}
+export MOE_GROUPED_GEMM=true
+
+export RUN_TIME=00:30:00
+export COMMENT=baseline
+export PR=${PR:-"bf16"}
+
+# GB200 config, BF16, 750 TFLOPS
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=2 PR=bf16 A2A_OVERLAP=0 TP=1 PP=8 VPP=1 EP=8 NNODES=64 MBS=1 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
+
+# GB200 config, MXFP8, 919 TFLOPS
+## This requires new feature: activation offloading, please check the PR status.
+PR=mxfp8 MBS=3 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep A2A_OVERLAP=1 TP=1 PP=4 VPP=6 EP=64 SEGMENT=16 NNODES=64 GBS=3072 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess --fine-grained-activation-offloading --offload-modules expert_fc1 moe_act --delay-offload-until-cuda-graph --use-separate-send-recv-groups
+

--- a/best_practice/qwen3/run_gb200_235b.sh
+++ b/best_practice/qwen3/run_gb200_235b.sh
@@ -35,6 +35,8 @@ export PR=${PR:-"bf16"}
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=2 PR=bf16 A2A_OVERLAP=0 TP=1 PP=8 VPP=1 EP=8 NNODES=64 MBS=1 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
 
 # GB200 config, MXFP8, 919 TFLOPS
-## This requires new feature: activation offloading, please check the PR status.
+## This requires new feature: activation offloading, please check the following PRs for usage:
+## MCore: https://github.com/NVIDIA/Megatron-LM/pull/3219
+## TransformerEngine: https://github.com/NVIDIA/TransformerEngine/pull/2716
 PR=mxfp8 MBS=3 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep A2A_OVERLAP=1 TP=1 PP=4 VPP=6 EP=64 SEGMENT=16 NNODES=64 GBS=3072 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess --fine-grained-activation-offloading --offload-modules expert_fc1 moe_act --delay-offload-until-cuda-graph --use-separate-send-recv-groups
 

--- a/best_practice/qwen3/run_gb200_235b.sh
+++ b/best_practice/qwen3/run_gb200_235b.sh
@@ -40,3 +40,5 @@ PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHE
 ## TransformerEngine: https://github.com/NVIDIA/TransformerEngine/pull/2716
 PR=mxfp8 MBS=3 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep A2A_OVERLAP=1 TP=1 PP=4 VPP=6 EP=64 SEGMENT=16 NNODES=64 GBS=3072 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess --fine-grained-activation-offloading --offload-modules expert_fc1 moe_act --delay-offload-until-cuda-graph --use-separate-send-recv-groups
 
+# GB200 config, MXFP8, 128k long context, 1150 TFLOPS
+PR=mxfp8 SEQ_LEN=131072 CP=4 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=4 PP=4 VPP=12 EP=32 NNODES=32 MBS=1 GBS=1024 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing

--- a/best_practice/qwen3/run_gb300_235b.sh
+++ b/best_practice/qwen3/run_gb300_235b.sh
@@ -9,7 +9,6 @@ export CLUSTER=${CLUSTER:-}
 export BINDPCIE_PATH=${BINDPCIE_PATH:-}
 
 # GB env
-# export SEGMENT=${SEGMENT:-8} # Should be EP // 4
 export NVLINK_DOMAIN_SIZE=72
 ## HybridEP settings, automatically set if using latest HybridEP
 # export USE_MNNVL=1
@@ -31,8 +30,5 @@ export RUN_TIME=00:30:00
 export COMMENT=baseline
 export PR=${PR:-"mxfp8"}
 
-# GB300 config, MXFP8, 974 TFLOPS
-PR=mxfp8 MBS=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=1 PP=4 VPP=1 EP=32 NNODES=64 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
-
-# GB300 config, MXFP8, 1150 TFLOPS, long context training
-PR=mxfp8 SEQ_LEN=131072 CP=4 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=4 PP=4 VPP=12 EP=32 NNODES=32 MBS=1 GBS=1024 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing
+# GB300 config, MXFP8, 1055 TFLOPS
+PR=mxfp8 MBS=1 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=16 A2A_OVERLAP=1 TP=1 PP=1 VPP=1 EP=64 NNODES=16 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess

--- a/best_practice/qwen3/run_gb300_235b.sh
+++ b/best_practice/qwen3/run_gb300_235b.sh
@@ -1,0 +1,38 @@
+# Cluster variables
+export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
+export ACCOUNT=${ACCOUNT:-}
+export MEGATRON_PATH=${MEGATRON_PATH:-}
+export PARTITION=${PARTITION:-}
+export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
+export CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
+export CLUSTER=${CLUSTER:-}
+export BINDPCIE_PATH=${BINDPCIE_PATH:-}
+
+# GB env
+# export SEGMENT=${SEGMENT:-8} # Should be EP // 4
+export NVLINK_DOMAIN_SIZE=72
+## HybridEP settings, automatically set if using latest HybridEP
+# export USE_MNNVL=1
+# export NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=32 # should be similar as EP
+
+# Model selection parameters
+export MODEL=${MODEL:-Qwen3-235B-A22B}
+export WANDB_PROJECT=${WANDB_PROJECT:-}
+export OUTPUT_PATH=${OUTPUT_PATH:-}
+
+# # Training parameters
+export PROFILE=0 # whether to profile the model with nsys profile
+export PRETRAIN=0 # whether train the model from scratch
+export MBS=${MBS:-1}
+export SEQ_LEN=${SEQ_LEN:-4096}
+export MOE_GROUPED_GEMM=true
+
+export RUN_TIME=00:30:00
+export COMMENT=baseline
+export PR=${PR:-"mxfp8"}
+
+# GB300 config, MXFP8, 974 TFLOPS
+PR=mxfp8 MBS=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=1 PP=4 VPP=1 EP=32 NNODES=64 GBS=8192 bash ./sbatch_benchmarking.sh --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope attn moe_router moe_preprocess
+
+# GB300 config, MXFP8, 1150 TFLOPS, long context training
+PR=mxfp8 SEQ_LEN=131072 CP=4 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=hybridep SEGMENT=8 A2A_OVERLAP=0 TP=4 PP=4 VPP=12 EP=32 NNODES=32 MBS=1 GBS=1024 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing

--- a/best_practice/qwen3/run_h100_235b.sh
+++ b/best_practice/qwen3/run_h100_235b.sh
@@ -1,0 +1,27 @@
+# Cluster variables
+export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
+export ACCOUNT=${ACCOUNT:-}
+export MEGATRON_PATH=${MEGATRON_PATH:-}
+export PARTITION=${PARTITION:-}
+export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
+export CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
+export CLUSTER=${CLUSTER:-}
+
+# Model selection parameters
+export MODEL=${MODEL:-Qwen3-235B-A22B}
+export WANDB_PROJECT=${WANDB_PROJECT:-}
+export OUTPUT_PATH=${OUTPUT_PATH:-}
+
+# # Training parameters
+export PROFILE=0 # whether to profile the model with nsys profile
+export PRETRAIN=0 # whether train the model from scratch
+export MBS=1
+export SEQ_LEN=4096
+export MOE_GROUPED_GEMM=true
+
+export RUN_TIME=00:30:00
+export COMMENT=baseline
+export PR=${PR:-"bf16"}
+
+# H100 config, 320 TFLOPS
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True NCCL_GRAPH_REGISTER=0 DISPATCHER=deepep A2A_OVERLAP=1 TP=2 PP=8 VPP=4 EP=32 NNODES=32 GBS=2048 bash ./sbatch_benchmarking.sh --recompute-granularity selective --recompute-modules moe_act layernorm --moe-router-force-load-balancing --cuda-graph-impl transformer_engine --cuda-graph-scope moe_router moe_preprocess

--- a/best_practice/readme.md
+++ b/best_practice/readme.md
@@ -2,8 +2,14 @@
 
 This directory provides best-practice guidance and reproducibility resources for Megatron-Core MoE training across representative models and GPU platforms.
 
-## Status
+## Models
 
-In conjunction with the upcoming technical report release, this folder will be updated with the latest verified performance results.
+| Model | Benchmarked Hardware | Directory |
+|-------|-------------------|-----------|
+| Qwen3-235B-A22B | H100, GB200, GB300 | [Qwen3/](Qwen3/) |
+| DeepSeek-V3 | H100, GB200 | [DeepSeekV3/](DeepSeekV3/) |
 
-Benchmark reproduction scripts referenced by the report will be published in this directory. These scripts are currently in preparation and will be released with accompanying usage instructions soon.
+## Quick Navigation
+
+- **Qwen3**: See [Qwen3/readme.md](Qwen3/readme.md) for performance results and reproduction scripts on H100, GB200, and GB300.
+- **DeepSeek-V3**: See [DeepSeekV3/readme.md](DeepSeekV3/readme.md) for performance results and reproduction scripts on H100 and GB200.

--- a/model_configs/benchmarking/Qwen3-235B-A22B.yaml
+++ b/model_configs/benchmarking/Qwen3-235B-A22B.yaml
@@ -13,7 +13,7 @@ ENV_VARS:
 
 MODEL_ARGS:
   # Distributed args
-  --distributed-timeout-minutes: 210
+  --distributed-timeout-minutes: 220
   --tensor-model-parallel-size: ${TP}
   --pipeline-model-parallel-size: ${PP}
   --num-layers-per-virtual-pipeline-stage: ${LAYERS_PER_VP}
@@ -72,7 +72,7 @@ MODEL_ARGS:
   --num-query-groups: 4
   --qk-layernorm: true
   --seq-length: ${SEQ_LEN}
-  --max-position-embeddings: 40960
+  --max-position-embeddings: ${SEQ_LEN}
   --make-vocab-size-divisible-by: 1187
 
   # Add regularization args

--- a/model_configs/benchmarking/Qwen3-235B-A22B.yaml
+++ b/model_configs/benchmarking/Qwen3-235B-A22B.yaml
@@ -16,6 +16,7 @@ MODEL_ARGS:
   --distributed-timeout-minutes: 210
   --tensor-model-parallel-size: ${TP}
   --pipeline-model-parallel-size: ${PP}
+  --num-layers-per-virtual-pipeline-stage: ${LAYERS_PER_VP}
   --expert-model-parallel-size: ${EP}
   --context-parallel-size: ${CP}
   --expert-tensor-parallel-size: 1
@@ -99,8 +100,6 @@ MODEL_ARGS:
   --moe-router-pre-softmax: false # Different from Qwen2-MoE
   --moe-grouped-gemm: ${MOE_GROUPED_GEMM}
   --moe-aux-loss-coeff: 1e-3
-  --moe-token-dispatcher-type: flex
-  --moe-enable-deepep: true
   --moe-permute-fusion: true
   --moe-router-fusion: true
   --moe-router-dtype: fp32
@@ -125,8 +124,8 @@ MODEL_ARGS:
   # Add logging args
   --log-timers-to-tensorboard: true
   --log-memory-to-tensorboard: true
-  --log-num-zeros-in-grad: true
-  --log-params-norm: true
+  # --log-num-zeros-in-grad: true
+  # --log-params-norm: true
   --log-validation-ppl-to-tensorboard: true
   --log-throughput: true
   --log-interval: 1

--- a/sbatch_benchmarking.sh
+++ b/sbatch_benchmarking.sh
@@ -165,6 +165,7 @@ mkdir -p ${SLURM_LOGS} || {
 TIMESTAMP=$(date +'%y%m%d_%H%M%S')
 
 # Set SBATCH_ARG based on cluster type
+SBATCH_ARG=""
 export GB200_CLUSTER=${GB200_CLUSTER:-0}
 if [[ "${GB200_CLUSTER}" == "1" ]]; then
     N_TASKS_PER_NODE=4


### PR DESCRIPTION
## Summary
- Add GB200 and GB300 reproduction scripts for Qwen3-235B-A22B benchmarking, plus an updated H100 script (`run_h100_235b.sh`, `run_gb200_235b.sh`, `run_gb300_235b.sh`).
- Update `best_practice/qwen3/readme.md` with H100 / GB200 / GB300 performance results, configurations, and commands (including MXFP8 + activation-offloading note).
- Update `best_practice/readme.md` with a model navigation table.
- Tweak `model_configs/benchmarking/Qwen3-235B-A22B.yaml`: expose `LAYERS_PER_VP`, drop hard-coded `moe-token-dispatcher-type: flex` / `moe-enable-deepep` (now controlled via env), and comment out `log-num-zeros-in-grad` / `log-params-norm`.
- Initialize `SBATCH_ARG=""` in `sbatch_benchmarking.sh` to avoid carrying stale values.

**[Note]** Claude code help aligned the commands by referring the full command from wandb logs. Have not tested the case directly using this repo but should reproduce similar results using similar code base, container and other experimental environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)