### PR TITLE
Add Kimi-K2/2.5 GB200 128K draft config

### DIFF
--- a/best_practice/kimi-k2/run_kimi_k2_gb200_128k_G128.sh
+++ b/best_practice/kimi-k2/run_kimi_k2_gb200_128k_G128.sh
@@ -1,0 +1,48 @@
+# GB200 Kimi-K2 128k TP16 PP2 EP64 benchmark
+export CLUSTER=${CLUSTER:-}
+export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}   # see dockers/GB200.Dockerfile
+export GB200_CLUSTER=1
+
+# bindpcie is recommended for GB200 CPU/memory affinity binding.
+# wget https://raw.githubusercontent.com/NVIDIA/mlperf-common/refs/heads/main/client/bindpcie
+# chmod +x bindpcie && export BINDPCIE_PATH=/path/to/bindpcie
+export BINDPCIE_PATH=${BINDPCIE_PATH:-}
+
+export MEGATRON_PATH=${MEGATRON_PATH:-}        # /path/to/Megatron-LM
+export MCORE_RELEASE_VERSION=${MCORE_RELEASE_VERSION:-0.16}
+
+export MODEL=Kimi-K2
+export RUN_NAME=${RUN_NAME:-"${MODEL}-gb200-128k"}
+export OUTPUT_PATH=${OUTPUT_PATH:-"${PWD}/outputs/${RUN_NAME}"}
+export WANDB_PROJECT=${WANDB_PROJECT:-megatron-moe-benchmarking}
+export WANDB_API_KEY=${WANDB_API_KEY:-}
+
+export PROFILE=${PROFILE:-0}
+export PRETRAIN=1
+export MBS=1
+export MOE_GROUPED_GEMM=true
+export RUN_TIME=${RUN_TIME:-00:30:00}
+export COMMENT=${COMMENT:-gb200-128k}
+export DISPATCHER=hybridep
+export OPTIMIZER_OFFLOAD=0
+export A2A_OVERLAP=0
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+
+export DATA_PATH=${DATA_PATH:-mock}
+export TOKENIZER_MODEL=${TOKENIZER_MODEL:-mock}
+export SEGMENT=${SEGMENT:-16}
+
+OPTIMIZER_OFFLOAD=${OPTIMIZER_OFFLOAD} A2A_OVERLAP=${A2A_OVERLAP} DISPATCHER=${DISPATCHER} MODEL=Kimi-K2 PP=2 TP=16 EP=64 CP=1 NNODES=32 GBS=128 SEQ_LEN=131072 PR=mxfp8 bash sbatch_benchmarking.sh \
+    --recompute-granularity selective \
+    --recompute-modules mla_up_proj mlp layernorm moe_act \
+    --pipeline-model-parallel-layout "'Et|t|(tt|)*29tL'" \
+    --fine-grained-activation-offloading \
+    --offload-modules expert_fc1 \
+    --te-rng-tracker \
+    --offload-optimizer-states \
+    --moe-permute-fusion-into-hybridep \
+    --moe-router-force-load-balancing \
+    --mock-data \
+    --tokenizer-type NullTokenizer --vocab-size 163840 \
+    --train-iters ${TRAIN_ITERS:-10} \
+    --eval-iters 0

--- a/best_practice/qwen3/run_gb200_235b.sh
+++ b/best_practice/qwen3/run_gb200_235b.sh
@@ -3,12 +3,12 @@ export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
 export ACCOUNT=${ACCOUNT:-}
 export MEGATRON_PATH=${MEGATRON_PATH:-}
 export PARTITION=${PARTITION:-}
-export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
 export CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
 export CLUSTER=${CLUSTER:-}
 export BINDPCIE_PATH=${BINDPCIE_PATH:-}
 
 # GB env
+export GB200_CLUSTER=1
 # export SEGMENT=${SEGMENT:-16} # Should be EP // 4
 export NVLINK_DOMAIN_SIZE=72
 ## HybridEP settings, automatically set if using latest HybridEP
@@ -17,6 +17,7 @@ export NVLINK_DOMAIN_SIZE=72
 
 # Model selection parameters
 export MODEL=${MODEL:-Qwen3-235B-A22B}
+export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
 export WANDB_PROJECT=${WANDB_PROJECT:-}
 export OUTPUT_PATH=${OUTPUT_PATH:-}
 

--- a/best_practice/qwen3/run_gb300_235b.sh
+++ b/best_practice/qwen3/run_gb300_235b.sh
@@ -3,12 +3,12 @@ export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
 export ACCOUNT=${ACCOUNT:-}
 export MEGATRON_PATH=${MEGATRON_PATH:-}
 export PARTITION=${PARTITION:-}
-export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
 export CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
 export CLUSTER=${CLUSTER:-}
 export BINDPCIE_PATH=${BINDPCIE_PATH:-}
 
 # GB env
+export GB200_CLUSTER=1
 export NVLINK_DOMAIN_SIZE=72
 ## HybridEP settings, automatically set if using latest HybridEP
 # export USE_MNNVL=1
@@ -16,6 +16,7 @@ export NVLINK_DOMAIN_SIZE=72
 
 # Model selection parameters
 export MODEL=${MODEL:-Qwen3-235B-A22B}
+export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
 export WANDB_PROJECT=${WANDB_PROJECT:-}
 export OUTPUT_PATH=${OUTPUT_PATH:-}
 

--- a/best_practice/qwen3/run_h100_235b.sh
+++ b/best_practice/qwen3/run_h100_235b.sh
@@ -3,12 +3,12 @@ export CONTAINER_IMAGE=${CONTAINER_IMAGE:-}
 export ACCOUNT=${ACCOUNT:-}
 export MEGATRON_PATH=${MEGATRON_PATH:-}
 export PARTITION=${PARTITION:-}
-export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
 export CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-}
 export CLUSTER=${CLUSTER:-}
 
 # Model selection parameters
 export MODEL=${MODEL:-Qwen3-235B-A22B}
+export RUN_NAME=${RUN_NAME:-"${MODEL}-benchmarking"}
 export WANDB_PROJECT=${WANDB_PROJECT:-}
 export OUTPUT_PATH=${OUTPUT_PATH:-}
 

--- a/best_practice/readme.md
+++ b/best_practice/readme.md
@@ -6,10 +6,10 @@ This directory provides best-practice guidance and reproducibility resources for
 
 | Model | Benchmarked Hardware | Directory |
 |-------|-------------------|-----------|
-| Qwen3-235B-A22B | H100, GB200, GB300 | [Qwen3/](Qwen3/) |
-| DeepSeek-V3 | H100, GB200 | [DeepSeekV3/](DeepSeekV3/) |
+| Qwen3-235B-A22B | H100, GB200, GB300 | [qwen3/](qwen3/) |
+| DeepSeek-V3 | H100, GB200 | [deepseek-v3/](deepseek-v3/) |
 
 ## Quick Navigation
 
-- **Qwen3**: See [Qwen3/readme.md](Qwen3/readme.md) for performance results and reproduction scripts on H100, GB200, and GB300.
-- **DeepSeek-V3**: See [DeepSeekV3/readme.md](DeepSeekV3/readme.md) for performance results and reproduction scripts on H100 and GB200.
+- **Qwen3**: See [qwen3/readme.md](qwen3/readme.md) for performance results and reproduction scripts on H100, GB200, and GB300.
+- **DeepSeek-V3**: See [deepseek-v3/readme.md](deepseek-v3/readme.md) for performance results and reproduction scripts on H100 and GB200.

--- a/model_configs/benchmarking/Kimi-K2.yaml
+++ b/model_configs/benchmarking/Kimi-K2.yaml
@@ -1,0 +1,151 @@
+ENV_VARS:
+  TORCH_NCCL_AVOID_RECORD_STREAMS: 0
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: 1
+  PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+  NCCL_NVLS_ENABLE: 0
+  NVTE_FUSED_ATTN: 1
+  NVTE_NORM_FWD_USE_CUDNN: 1
+  NVTE_NORM_BWD_USE_CUDNN: 1
+  PYTHONWARNINGS: ignore
+  NCCL_DEBUG: VERSION
+  NCCL_GRAPH_REGISTER: 0
+
+MODEL_ARGS:
+  # Distributed args
+  --distributed-timeout-minutes: 60
+  --tensor-model-parallel-size: ${TP}
+  --pipeline-model-parallel-size: ${PP}
+  --expert-model-parallel-size: ${EP}
+  --context-parallel-size: ${CP}
+  --expert-tensor-parallel-size: 1
+  --use-distributed-optimizer: true
+  --overlap-grad-reduce: true
+  --overlap-param-gather: true
+
+  # Training args
+  --use-mcore-models: true
+  --sequence-parallel: true
+  --use-flash-attn: true
+  --disable-bias-linear: true
+  --micro-batch-size: ${MBS}
+  --global-batch-size: ${GBS}
+  --train-samples: 585937500
+  --exit-duration-in-mins: 220
+  --no-save-optim: true
+  --no-check-for-nan-in-loss-and-grad: true
+  --cross-entropy-loss-fusion: true
+  --cross-entropy-fusion-impl: native
+  --manual-gc: true
+  --manual-gc-interval: 10
+
+  # Transformer Engine args
+  --transformer-impl: transformer_engine
+
+  # Data args
+  --seq-length: ${SEQ_LEN}
+  --data-cache-path: ${WORKSPACE}/data_cache
+  --tokenizer-type: HuggingFaceTokenizer
+  --tokenizer-model: moonshotai/Kimi-K2-Instruct
+  --data-path: ${DATA_PATH}
+  --split: 99,1,0
+  --no-mmap-bin-files: true
+  --no-create-attention-mask-in-dataloader: true
+  --num-workers: 6
+
+  # Network size args
+  --num-layers: 61
+  --hidden-size: 7168
+  --ffn-hidden-size: 18432
+  --num-attention-heads: 64
+  --kv-channels: 64
+  --max-position-embeddings: 4096
+  --position-embedding-type: rope
+  --rotary-base: 50000
+  --make-vocab-size-divisible-by: 1280
+  --normalization: RMSNorm
+  --norm-epsilon: 1e-6
+  --swiglu: true
+  --untie-embeddings-and-output-weights: true
+  --multi-latent-attention: true
+
+  # Regularization args
+  --attention-dropout: 0.0
+  --hidden-dropout: 0.0
+  --clip-grad: 1.0
+  --weight-decay: 0.1
+  --qk-layernorm: true
+
+  # Learning rate args
+  --lr-decay-samples: 584765624
+  --lr-warmup-samples: 1536000
+  --lr-warmup-init: 3.9e-7
+  --lr: 3.9e-6
+  --min-lr: 3.9e-7
+  --lr-decay-style: cosine
+  --adam-beta1: 0.9
+  --adam-beta2: 0.95
+
+  # MoE args
+  --num-experts: 384
+  --moe-layer-freq: "'([0]*1+[1]*60)'"
+  --moe-ffn-hidden-size: 2048
+  --moe-shared-expert-intermediate-size: 2048
+  --moe-router-load-balancing-type: seq_aux_loss
+  --moe-router-topk: 8
+  --moe-grouped-gemm: true
+  --moe-aux-loss-coeff: 0
+  --moe-router-group-topk: 1
+  --moe-router-num-groups: 1
+  --moe-router-topk-scaling-factor: 2.827
+  --moe-router-score-function: sigmoid
+  --moe-router-enable-expert-bias: true
+  --moe-router-bias-update-rate: 1e-3
+  --moe-router-dtype: fp32
+  --moe-permute-fusion: true
+  --moe-router-fusion: true
+
+  # MLA args
+  --q-lora-rank: 1536
+  --kv-lora-rank: 512
+  --qk-head-dim: 128
+  --qk-pos-emb-head-dim: 64
+  --v-head-dim: 128
+  --rotary-scaling-factor: 32
+  --mscale: 1.0
+  --mscale-all-dim: 1.0
+
+  # Validation args
+  --eval-iters: 32
+  --eval-interval: 200
+
+  # Checkpointing args
+  --finetune: false
+  --no-load-optim: true
+  --no-load-rng: true
+  --auto-detect-ckpt-format: true
+  --load: false
+  --save: ${OUTPUT_PATH}/checkpoints
+  --save-interval: 500
+  --dist-ckpt-strictness: log_all
+
+  # Initialization args
+  --init-method-std: 0.02
+
+  # Logging args
+  --log-timers-to-tensorboard: true
+  --log-memory-to-tensorboard: true
+  --log-num-zeros-in-grad: false
+  --log-params-norm: false
+  --log-validation-ppl-to-tensorboard: true
+  --log-throughput: true
+  --log-interval: 1
+  --logging-level: 40
+  --tensorboard-dir: ${OUTPUT_PATH}/tensorboard
+  --wandb-project: ${WANDB_PROJECT}
+  --wandb-exp-name: Kimi-K2-TP${TP}PP${PP}EP${EP}CP${CP}VPP${VPP}-MBS${MBS}GBS${GBS}-${COMMENT}
+
+  # Mixed precision args
+  --bf16: true
+
+  # Experimental args
+  --enable-experimental: true

--- a/runtime_configs/benchmarking/runtime.conf
+++ b/runtime_configs/benchmarking/runtime.conf
@@ -13,6 +13,7 @@ declare -A BENCHMARKING_MODEL_CONFIGS=(
     [Qwen3-235B-A22B]="     2  8  32 1  4   1   256   96    flex         true       32    00:20:00    0     4096  CustomDataset" # Account loss and embedding for number of layers
     [Qwen3-30B-A3B]="       1  1  8  1  1   1   256   48    alltoall     true       4     00:20:00    0     4096  CustomDataset"   
     [Qwen3-Next-80B-A3B]="  1  4  8  1  3   1   256   48    flex         true       8     00:20:00    0     4096  CustomDataset"
+    [Kimi-K2]="             1  4  64 1  4   1   128   61    deepep       true       16    00:30:00    0     4096  CustomDataset    4  1"
 )
 
 # Function to set model configurations based on model name


### PR DESCRIPTION
## Summary

- Add a public-safe Kimi-K2 GB200 128k benchmark launcher and model config.
- Register Kimi-K2 in the runtime benchmark defaults.
- Fix Qwen3 benchmark launcher defaults found during review: GB200/GB300 now enter the GB200 cluster branch, Qwen run names include the model name, and best-practice links match the actual directory names.

## Validation

- `bash -n best_practice/kimi-k2/run_kimi_k2_gb200_128k_G128.sh`
- `yq '.' model_configs/benchmarking/Kimi-K2.yaml >/dev/null`
- `git diff --check`
- `cwslurm` dry run: `DRY_RUN=1 CLUSTER=template bash best_practice/kimi-k2/run_kimi_k2_gb200_128k_G128.sh`
- `cwslurm` dry runs for Qwen3 H100, GB200, and GB300 launchers

## Notes

The Kimi launcher uses mock data and public placeholder paths by default. It does not include Periodic-specific W&B, image, user, or filesystem paths.
